### PR TITLE
Fix chat log file overwrite bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,10 +63,14 @@ def log_chat(user_text, juno_reply):
                 json.dump([log_entry], f, indent=4)
         else:
             with open(CHAT_LOG_FILE, "r+") as f:
-                data = json.load(f)
+                try:
+                    data = json.load(f)
+                except json.JSONDecodeError:
+                    data = []
                 data.append(log_entry)
                 f.seek(0)
                 json.dump(data, f, indent=4)
+                f.truncate()
     except Exception as e:
         print(f"❌ Chat log failed: {e}")
 


### PR DESCRIPTION
## Summary
- fix `log_chat` to truncate the file after writing
- handle `JSONDecodeError` when chat log is corrupted

## Testing
- `python -m py_compile main.py morning_task.py send_push.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df7fb6fb0832393690af1e2c63b7c